### PR TITLE
Fix `skyux watch`

### DIFF
--- a/config/webpack/serve.webpack.config.js
+++ b/config/webpack/serve.webpack.config.js
@@ -93,10 +93,6 @@ function getWebpackConfig(argv, skyPagesConfig) {
         key: fs.readFileSync(path.join(__dirname, '../../ssl/server.key')),
         cert: fs.readFileSync(path.join(__dirname, '../../ssl/server.crt'))
       },
-      watchOptions: {
-        aggregateTimeout: 300,
-        poll: 1000
-      },
       publicPath: skyPagesConfigUtil.getAppBase(skyPagesConfig)
     },
 


### PR DESCRIPTION
- Removed Webpack Dev Server `watchOptions` since we don't need polling, and `300` is the default value for `aggregateTimeout`.
- See: https://webpack.js.org/configuration/watch/#watchoptions