### PR TITLE
Fix `typeRoots` to be an absolute path; remove `types`

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -77,10 +77,7 @@ function writeTSConfig() {
         'es6'
       ],
       'typeRoots': [
-        'node_modules/@types'
-      ],
-      'types': [
-        'node'
+        skyPagesConfigUtil.spaPath('node_modules', '@types')
       ],
       'outDir': skyPagesConfigUtil.spaPath('dist'),
       'rootDir': skyPagesConfigUtil.spaPathTemp(),


### PR DESCRIPTION
This was a mistake on my part from a previous pull request: https://github.com/blackbaud/skyux-sdk-builder/pull/16/files#diff-21181889e04ddb7d6f9b6265839b0dfdR79.

For one, I failed to remove the existing `types` definition (can't have both `types` and `typeRoots`). Also, the `typeRoots` need to be provided relative to the SPA, not Builder.