### PR TITLE
[HOLD] Fix assets to not throw 404 during unit tests

### DIFF
--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -70,6 +70,14 @@ function getWebpackConfig(skyPagesConfig, argv) {
         },
         {
           enforce: 'pre',
+          test: [
+            /\.(html|s?css)$/,
+            /sky-pages\.module\.ts/
+          ],
+          loader: outPath('loader', 'sky-assets')
+        },
+        {
+          enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
           loader: outPath('loader', 'sky-pages-module')
         },

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -85,7 +85,7 @@ function getWebpackConfig(skyPagesConfig, argv) {
             /\.(html|s?css)$/,
             /sky-pages\.module\.ts/
           ],
-          loader: outPath('loader', 'sky-assets')
+          loader: outPath('loader', 'sky-assets', 'mock-loader')
         },
         {
           enforce: 'pre',

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -70,14 +70,6 @@ function getWebpackConfig(skyPagesConfig, argv) {
         },
         {
           enforce: 'pre',
-          test: [
-            /\.(html|s?css)$/,
-            /sky-pages\.module\.ts/
-          ],
-          loader: outPath('loader', 'sky-assets')
-        },
-        {
-          enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
           loader: outPath('loader', 'sky-pages-module')
         },
@@ -86,6 +78,14 @@ function getWebpackConfig(skyPagesConfig, argv) {
           test: /\.js$/,
           loader: 'source-map-loader',
           exclude: excludes
+        },
+        {
+          enforce: 'pre',
+          test: [
+            /\.(html|s?css)$/,
+            /sky-pages\.module\.ts/
+          ],
+          loader: outPath('loader', 'sky-assets')
         },
         {
           enforce: 'pre',

--- a/lib/assets-processor.js
+++ b/lib/assets-processor.js
@@ -12,12 +12,6 @@ const {
 
 const ASSETS_REGEX = /~\/assets\/.*?\.[\.\w]+/gi;
 
-function getCliCommand() {
-  const minimist = require('minimist');
-  const argv = minimist(process.argv.slice(2));
-  return argv._[0];
-}
-
 /**
  * Gets the assets URL with the application's root directory appended to it.
  * @param {*} skyPagesConfig The SKY UX app config.
@@ -61,20 +55,7 @@ function processAssets(content, baseUrl, callback) {
       callback(filePathWithHash, skyPagesConfigUtil.spaPath('src', filePath));
     }
 
-    const cliCommand = getCliCommand();
-    let url;
-    switch (cliCommand) {
-      // Replace the URL with an empty string if we're running unit tests.
-      // This will prevent 404 warnings appearing in the log.
-      case 'test':
-      case 'watch':
-        url = '';
-        break;
-
-      default:
-        url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
-        break;
-    }
+    const url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
 
     content = content.replace(
       new RegExp(matchString, 'gi'),
@@ -108,6 +89,7 @@ function setSkyAssetsLoaderUrl(webpackConfig, skyPagesConfig, baseUrl, rel) {
 }
 
 module.exports = {
+  ASSETS_REGEX,
   getAssetsUrl,
   setSkyAssetsLoaderUrl,
   processAssets

--- a/lib/assets-processor.js
+++ b/lib/assets-processor.js
@@ -61,16 +61,19 @@ function processAssets(content, baseUrl, callback) {
       callback(filePathWithHash, skyPagesConfigUtil.spaPath('src', filePath));
     }
 
-    let url;
     const cliCommand = getCliCommand();
-    // Replace the URL with an empty string if we're running unit tests.
-    if (
-      cliCommand === 'test' ||
-      cliCommand === 'watch'
-    ) {
-      url = '';
-    } else {
-      url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
+    let url;
+    switch (cliCommand) {
+      // Replace the URL with an empty string if we're running unit tests.
+      // This will prevent 404 warnings appearing in the log.
+      case 'test':
+      case 'watch':
+        url = '';
+        break;
+
+      default:
+        url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
+        break;
     }
 
     content = content.replace(

--- a/lib/assets-processor.js
+++ b/lib/assets-processor.js
@@ -12,6 +12,12 @@ const {
 
 const ASSETS_REGEX = /~\/assets\/.*?\.[\.\w]+/gi;
 
+function getCliCommand() {
+  const minimist = require('minimist');
+  const argv = minimist(process.argv.slice(2));
+  return argv._[0];
+}
+
 /**
  * Gets the assets URL with the application's root directory appended to it.
  * @param {*} skyPagesConfig The SKY UX app config.
@@ -55,7 +61,17 @@ function processAssets(content, baseUrl, callback) {
       callback(filePathWithHash, skyPagesConfigUtil.spaPath('src', filePath));
     }
 
-    const url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
+    let url;
+    const cliCommand = getCliCommand();
+    // Replace the URL with an empty string if we're running unit tests.
+    if (
+      cliCommand === 'test' ||
+      cliCommand === 'watch'
+    ) {
+      url = '';
+    } else {
+      url = `${baseUrl}${filePathWithHash.replace(/\\/gi, '/')}`;
+    }
 
     content = content.replace(
       new RegExp(matchString, 'gi'),

--- a/loader/sky-assets/mock-loader.js
+++ b/loader/sky-assets/mock-loader.js
@@ -1,0 +1,25 @@
+/*jshint node: true*/
+'use strict';
+
+const {
+  ASSETS_REGEX
+} = require('../../lib/assets-processor');
+
+module.exports = function (content) {
+  let match = ASSETS_REGEX.exec(content);
+
+  while (match) {
+    const matchString = match[0];
+
+    // Replace the URL with an empty string if we're running unit tests.
+    // This will prevent 404 warnings appearing in the log.
+    content = content.replace(
+      new RegExp(matchString, 'gi'),
+      ''
+    );
+
+    match = ASSETS_REGEX.exec(content);
+  }
+
+  return content;
+};

--- a/test/loader-assets-mock.spec.js
+++ b/test/loader-assets-mock.spec.js
@@ -1,0 +1,19 @@
+const mock = require('mock-require');
+
+describe('SKY UX mock assets Webpack loader', function () {
+  let loader;
+
+  beforeEach(function () {
+    loader = mock.reRequire('../loader/sky-assets/mock-loader');
+  });
+
+  afterEach(function () {
+    mock.stopAll();
+  });
+
+  it('should replace assets URL with an empty string', function () {
+    const html = '<div><img src="~/assets/image.jpg"></div>';
+    const modified = loader(html);
+    expect(modified).toEqual('<div><img src=""></div>');
+  });
+});


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-sdk-builder/issues/34

Use a mock loader to convert all paths to an empty string `""` (unit tests only).