### PR TITLE
Fix `SkyPagesModule` to provide `SkyAppWindowRef`

### DIFF
--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -67,6 +67,7 @@ function getSource(skyAppConfig) {
   ];
 
   let runtimeProviders = [
+    'SkyAppWindowRef',
     `{
       provide: SkyAppConfig,
       deps: [

--- a/test/sky-pages-module-generator.spec.js
+++ b/test/sky-pages-module-generator.spec.js
@@ -398,4 +398,17 @@ require('style-loader!src/styles/custom.css');
     expect(source).not.toContain(`require('style-loader!https://google.com/styles.css');`);
     expect(spy.calls.first().args[0]).toContain('External style sheets are not permitted');
   });
+
+  it('should provide SkyAppWindowRef', () => {
+    const generator = mock.reRequire(GENERATOR_PATH);
+    const expectedProvider = `providers: [
+    SkyAppWindowRef,`;
+
+    const source = generator.getSource({
+      runtime: runtimeUtils.getDefaultRuntime(),
+      skyux: runtimeUtils.getDefaultSkyux()
+    });
+
+    expect(source).toContain(expectedProvider);
+  });
 });


### PR DESCRIPTION
We recently updated `@skyux/i18n` to not have a dependency on `@skyux/core`. This inadvertently affected Builder because it uses `SkyAppWindowRef` internally, but does not provide it within `SkyPagesModule` (previously, the `SkyI18nModule` was providing the window reference, and Builder wasn't throwing an error because it is importing `SkyI18nModule`).

This change makes Builder provide the window reference explicitly, since it's using it internally.