### PR TITLE
fix: adjust coverage thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 .e2e-tmp
 yarn.lock
 .skypageslocales
+
+# IDE files
+.idea/

--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -13,10 +13,10 @@ function getCoverageThreshold(skyPagesConfig) {
       return 0;
 
     case 'standard':
-      return 80;
+      return 60;
 
     case 'strict':
-      return 100;
+      return 80;
   }
 }
 

--- a/test/config-karma-shared.spec.js
+++ b/test/config-karma-shared.spec.js
@@ -262,14 +262,15 @@ describe('config karma shared', () => {
     });
 
     it('should handle codeCoverageThreshold set to "standard"', () => {
-      checkCodeCoverage('standard', 80, 79, false);
-      checkCodeCoverage('standard', 80, 80, true);
-      checkCodeCoverage('standard', 80, 81, true);
+      checkCodeCoverage('standard', 60, 59, false);
+      checkCodeCoverage('standard', 60, 60, true);
+      checkCodeCoverage('standard', 60, 61, true);
     });
 
     it('should handle codeCoverageThreshold set to "strict"', () => {
-      checkCodeCoverage('strict', 100, 99, false);
-      checkCodeCoverage('strict', 100, 100, true);
+      checkCodeCoverage('strict', 80, 79, false);
+      checkCodeCoverage('strict', 80, 80, true);
+      checkCodeCoverage('strict', 80, 81, true);
     });
   });
 


### PR DESCRIPTION
I submit this as a possible workaround for #31. Since it seems like the real solution is to move fro `instanbul` to `nyc`, which i assume isn't happening soon, this change allows for people using the 80% coverage to drop to something _not_ 0.

An internal slack thread indicated that people who used to be on 100% are now setting this to 80%. But that leaves people like me, who were previously on 80%, with the only option of going all the way down to 0%. This change will allow the previous 80%-ers to go to 60%, which is much better than 0.

This makes high-level sense since 100% is not possible, our definition of strict can't be 100%.

But it's a temporary fix. Obviously the real fix is to move to `nyc` and then these definitions should go back to what they were. 

This should also be weighed against #70. I couldn't determine how that would fix the issue, but if it does, then my pr should be ignored/reverted.