### PR TITLE
Disable node environment for tests

### DIFF
--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -143,7 +143,20 @@ function getWebpackConfig(skyPagesConfig, argv) {
         spaPath('src'),
         {}
       )
-    ]
+    ],
+
+    /**
+     * Angular 7 animations module has an internal check to determine if the environment is
+     * using Node. If it is, it manually removes the `String.matches` polyfill to avoid
+     * conflicts with Node's native matches function. Angular CLI automatically handles this
+     * behavior, but we need to manually unset Node's `process` property since we're using a custom
+     * webpack config (Angular checks if `process` exists on the global object to determine
+     * if the environment is running in Node).
+     * See: https://github.com/angular/angular/issues/24769#issuecomment-405498008
+     */
+    node: {
+      process: false
+    }
   };
 
   if (runCoverage) {


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-sdk-builder/issues/108

This is copy/paste from the common config:
https://github.com/blackbaud/skyux-sdk-builder/blob/master/config/webpack/common.webpack.config.js#L217-L219