### PR TITLE
Fix library UMD bundle generator

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -112,23 +112,6 @@ function writeTSConfig() {
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('tsconfig.json'), config);
 }
 
-/**
- * Create a "placeholder" module for Angular AoT compiler.
- * This is needed to avoid breaking changes; in the future,
- * we should require a module name be provided by the consumer.
- */
-function writePlaceholderModule() {
-  const content = `import { NgModule } from '@angular/core';
-export * from './index';
-@NgModule({})
-export class SkyLibPlaceholderModule {}
-`;
-
-  fs.writeFileSync(skyPagesConfigUtil.spaPathTemp('main.ts'), content, {
-    encoding: 'utf8'
-  });
-}
-
 function processFiles(skyPagesConfig) {
   const pluginFileProcessor = require('../lib/plugin-file-processor');
   pluginFileProcessor.processFiles(
@@ -184,7 +167,6 @@ module.exports = (argv, skyPagesConfig, webpack) => {
   cleanAll();
   stageTypeScriptFiles();
   writeTSConfig();
-  writePlaceholderModule();
   copyRuntime();
   processFiles(skyPagesConfig);
 

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -170,8 +170,8 @@ module.exports = (argv, skyPagesConfig, webpack) => {
   copyRuntime();
   processFiles(skyPagesConfig);
 
-  return createBundle(skyPagesConfig, webpack)
-    .then(() => transpile())
+  return transpile()
+    .then(() => createBundle(skyPagesConfig, webpack))
     .then(() => {
       cleanRuntime();
       preparePackage();

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -1,7 +1,6 @@
 /*jslint node: true */
 'use strict';
 
-const { AngularCompilerPlugin } = require('@ngtools/webpack');
 const fs = require('fs-extra');
 const skyPagesConfigUtil = require('../sky-pages/sky-pages.config');
 
@@ -48,7 +47,7 @@ function getWebpackConfig(skyPagesConfig) {
 
   return {
     mode: 'production',
-
+    devtool: 'source-map',
     entry: skyPagesConfigUtil.spaPathTemp('index.ts'),
     output: {
       path: skyPagesConfigUtil.spaPath('dist', 'bundles'),
@@ -64,8 +63,14 @@ function getWebpackConfig(skyPagesConfig) {
       rules: [
         {
           test: /\.ts$/,
-          use: ['awesome-typescript-loader', 'angular2-template-loader'],
-          exclude: [/\.(spec|e2e)\.ts$/]
+          use: [
+            'awesome-typescript-loader',
+            'angular2-template-loader'
+          ],
+          exclude: [
+            /node_modules/,
+            /\.(e2e-|pact-)?spec\.ts$/
+          ]
         },
         {
           test: /\.html$/,
@@ -80,16 +85,7 @@ function getWebpackConfig(skyPagesConfig) {
           use: ['raw-loader', 'style-loader']
         }
       ]
-    },
-    plugins: [
-      // Generates an AoT JavaScript bundle.
-      new AngularCompilerPlugin({
-        tsConfigPath: skyPagesConfigUtil.spaPathTemp('tsconfig.json'),
-        entryModule: skyPagesConfigUtil.spaPathTemp('main.ts') + '#SkyLibPlaceholderModule',
-        sourceMap: false,
-        typeChecking: false
-      })
-    ]
+    }
   };
 }
 

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -47,7 +47,7 @@ function getWebpackConfig(skyPagesConfig) {
 
   return {
     mode: 'production',
-    devtool: 'source-map',
+
     entry: skyPagesConfigUtil.spaPathTemp('index.ts'),
     output: {
       path: skyPagesConfigUtil.spaPath('dist', 'bundles'),

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -34,11 +34,11 @@ describe('cli build-public-library', () => {
       return {
         run: (cb) => {
           cb(null, {
-          toJson: () => ({
-            errors: [],
-            warnings: []
-          })
-        });
+            toJson: () => ({
+              errors: [],
+              warnings: []
+            })
+          });
         }
       };
     };
@@ -115,21 +115,6 @@ describe('cli build-public-library', () => {
     cliCommand({}, {}, mockWebpack).then(() => {
       const firstArg = spy.calls.argsFor(0)[0];
       expect(firstArg).toEqual('tsconfig.json');
-      done();
-    });
-  });
-
-  it('should write a placeholder module file', (done) => {
-    const cliCommand = mock.reRequire(requirePath);
-    const spy = spyOn(mockFs, 'writeFileSync').and.callThrough();
-    cliCommand({}, {}, mockWebpack).then(() => {
-      const args = spy.calls.argsFor(0);
-      expect(args[0]).toEqual('main.ts');
-      expect(args[1]).toEqual(`import { NgModule } from '@angular/core';
-export * from './index';
-@NgModule({})
-export class SkyLibPlaceholderModule {}
-`);
       done();
     });
   });

--- a/test/config-webpack-build-public-library.spec.js
+++ b/test/config-webpack-build-public-library.spec.js
@@ -116,18 +116,4 @@ describe('config webpack build public library', () => {
     const config = lib.getWebpackConfig(skyPagesConfig);
     expect(config.externals).toEqual([]);
   });
-
-  it('should setup AOT compilation', () => {
-    const spy = spyOn(mockNgTools, 'AngularCompilerPlugin').and.callThrough();
-    const lib = mock.reRequire(configPath);
-
-    lib.getWebpackConfig(skyPagesConfig);
-
-    expect(spy).toHaveBeenCalledWith({
-      tsConfigPath: 'temp',
-      entryModule: 'temp#SkyLibPlaceholderModule',
-      sourceMap: false,
-      typeChecking: false
-    });
-  });
 });


### PR DESCRIPTION
When running a SKY UX 3 library in Stackblitz I get the following error:
```
Can't export value function(){} from AppSkyModule as it was neither declared nor imported!
```
The `function(){}` refers to an unrecognized module (e.g. `SkyPopoverModule`). Stackblitz pulls from the generated UMD module, not the transpiled es6 module. After following a few tutorials on how to setup a UMD module for Angular libraries, I'm fairly certain that our implementation of `AngularCompilerPlugin` during the UMD compilation is causing problems. The tutorials simply use `ngc` CLI to create AoT files, then compile the AoT files into a UMD bundle.

**You can reproduce the error locally by importing the library using a `require` statement:**
```
const popovers = require('@skyux/popovers/bundles/bundle.umd');

@NgModule({
  exports: [
    popovers.SkyPopoverModule
  ]
})
export class AppExtrasModule { }
```

To test out this theory, I released an alpha version of `@skyux/popovers` that was built using this branch.

**StackBlitz demonstrating the error:**
https://stackblitz.com/edit/angular-9zubce

**StackBlitz demonstrating the fix (built using this branch):**
https://stackblitz.com/edit/angular-9zubce-49cfst

Note that the only difference between the two StackBlitz demos is the version of `@skyux/popovers`.

**Tutorials around UMD compilation:**
https://github.com/robisim74/angular-library-starter/blob/master/build.js#L46
https://medium.com/@trekhleb/how-to-create-aot-jit-compatible-angular-4-library-with-external-scss-html-templates-9da6e68dac6e
https://github.com/trekhleb/angular-library-seed