### PR TITLE
Remove `no-use-before-declare` TSLint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -67,7 +67,6 @@
     "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "radix": true,
     "switch-default": true,


### PR DESCRIPTION
During a build, I see the following warning in the console:
```
no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
```

According to TSLint's documentation, this rule should not be used.
See: https://palantir.github.io/tslint/rules/no-use-before-declare/
"This rule is primarily useful when using the var keyword since the compiler will automatically detect if a block-scoped let and const variable is used before declaration. Since most modern TypeScript doesn’t use var, this rule is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions."