### PR TITLE
Add `ajv` to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,17 @@
         "source-map": "0.7.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+          "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "rxjs": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
@@ -959,9 +970,9 @@
       }
     },
     "ajv": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@pact-foundation/pact-node": "8.6.0",
     "@types/jasmine": "3.3.13",
     "@types/node": "12.0.8",
+    "ajv": "6.10.0",
     "angular2-template-loader": "0.6.2",
     "async": "2.6.2",
     "awesome-typescript-loader": "5.2.1",


### PR DESCRIPTION
This will address the following missing-peer warning when SPAs install Builder:
```
npm WARN ajv-keywords@3.4.0 requires a peer of ajv@^6.9.1 but none is installed. You must install peer dependencies yourself.
```

Angular CLI fixed it in a similar manner: https://github.com/angular/angular-cli/pull/13645