### PR TITLE
Fixed invalid import for `skyux generate` component spec

### DIFF
--- a/cli/generate.js
+++ b/cli/generate.js
@@ -85,8 +85,11 @@ function generateComponentSpec(pathParts, fileName, name, nameSnakeCase, force) 
 } from '@angular/core/testing';
 
 import {
-  expect,
   SkyAppTestModule
+} from '@skyux-sdk/builder/runtime/testing/browser';
+
+import {
+  expect
 } from '@skyux-sdk/testing';
 
 import {


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-sdk-builder/issues/133