### PR TITLE
Fix `skyux build` to ignore fixtures directory

### DIFF
--- a/cli/utils/run-build.js
+++ b/cli/utils/run-build.js
@@ -58,7 +58,7 @@ function writeTSConfig(skyPagesConfig) {
       '**/*'
     ],
     'exclude': [
-      'fixtures',
+      '**/fixtures/**',
       'node_modules',
       '**/*.spec.ts',
       '**/*.fixture.ts'


### PR DESCRIPTION
Currently, files found in a `/fixtures/` directory are NOT excluded from the bundle (even though we have a pattern listed in `skyux build`'s *tsconfig.json* file).
