### PR TITLE
feat: pass envid & perm scope to help widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10327,6 +10327,16 @@
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"
+              },
+              "dependencies": {
+                "https-proxy-agent-snyk-fork": {
+                  "version": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
+                  "from": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                  "requires": {
+                    "agent-base": "^4.3.0",
+                    "debug": "^3.1.0"
+                  }
+                }
               }
             },
             "pac-resolver": {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -721,6 +721,36 @@ describe('AppComponent', () => {
     });
   }));
 
+  it('should assign help config environmentId to the envid if one exists', async(() => {
+    const spyHelp = spyOn(mockHelpInitService, 'load');
+    const expectedCall = { productId: 'test-config', environmentId: 't-Z-FEhKwLvkGVGjTCcbBMEA' };
+    skyAppConfig.skyux.help = { productId: 'test-config' };
+
+    skyAppConfig.skyux.params = ['envid'];
+    skyAppConfig.runtime.params.has = (key: any) => key === 'envid';
+    skyAppConfig.runtime.params.get = (key: any) => key === 'envid' ? expectedCall.environmentId : false;
+
+    setup(skyAppConfig).then(() => {
+      fixture.detectChanges();
+      expect(spyHelp).not.toHaveBeenCalledWith(skyAppConfig.skyux.help);
+      expect(spyHelp).toHaveBeenCalledWith(expectedCall);
+    });
+  }));
+
+  it('should assign help config permissionScope to the access resolver\'s scope if one exists', async(() => {
+    const spyHelp = spyOn(mockHelpInitService, 'load');
+    const expectedCall = { productId: 'test-config', permissionScope: 'myScope' };
+    skyAppConfig.skyux.help = { productId: 'test-config' };
+
+    skyAppConfig.skyux.appSettings = {accessResolver: {globalPermissionsScope: expectedCall.permissionScope}};
+
+    setup(skyAppConfig).then(() => {
+      fixture.detectChanges();
+      expect(spyHelp).not.toHaveBeenCalledWith(skyAppConfig.skyux.help);
+      expect(spyHelp).toHaveBeenCalledWith(expectedCall);
+    });
+  }));
+
   it('should assign help config locale key if none exist and host exposes the browser language', async(() => {
     const spyHelp = spyOn(mockHelpInitService, 'load');
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -297,6 +297,14 @@ export class AppComponent implements OnInit, OnDestroy {
         if (this.config.runtime.params.has('svcid')) {
           helpConfig.extends = this.config.runtime.params.get('svcid');
         }
+        if (this.config.runtime.params.has('envid')) {
+          helpConfig.environmentId = this.config.runtime.params.get('envid');
+        }
+        if (this.config.skyux.appSettings
+          && this.config.skyux.appSettings.accessResolver
+          && this.config.skyux.appSettings.accessResolver.globalPermissionsScope) {
+          helpConfig.permissionScope = this.config.skyux.appSettings.accessResolver.globalPermissionsScope;
+        }
 
         if (skyuxHost && !helpConfig.locale) {
           const browserLanguages = skyuxHost.acceptLanguage || '';


### PR DESCRIPTION
Passing the envid and perm scope to the help widget will allow it to do things with `BBAuth` which is needed for hiding help content based upon authentication/entitlements.

I don't want to merge this right away. I'd like to chat with someone with SKY UX on the rollout of this. I _think_ it's a simple minor version bump, but would like some :eyes: on that before merging/releasing. I also suspect that SKY UX might want to know more about the authentication/entitlement work/requirements for the help widget before reviewing.

But for now, I just want to see if the ~20 min build will pass.