### PR TITLE
Unit test assets

### DIFF
--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -78,7 +78,7 @@ function getConfig(config) {
       }
     ],
     proxies: {
-      '/~/': `/absolute/${srcPath}`
+      '/~/': `/absolute${srcPath}`
     },
     preprocessors: preprocessors,
     skyPagesConfig: skyPagesConfig,

--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -44,6 +44,7 @@ function getConfig(config) {
   const polyfillsBundle = `${__dirname}/../../src/polyfills.ts`;
 
   // Used in conjunction with `proxies` property to remove 404 and correctly serve assets
+  // Karma normalizes the pattern before glob, so no need to accomodate different OSes.
   const assetsPattern = `${srcPath}/assets/**`;
 
   const preprocessors = {};

--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -43,6 +43,9 @@ function getConfig(config) {
   const specStyles = `${__dirname}/../../utils/spec-styles.js`;
   const polyfillsBundle = `${__dirname}/../../src/polyfills.ts`;
 
+  // Used in conjunction with `proxies` property to remove 404 and correctly serve assets
+  const assetsPattern = `${srcPath}/assets/**`;
+
   const preprocessors = {};
 
   preprocessors[polyfillsBundle] = ['webpack'];
@@ -67,8 +70,16 @@ function getConfig(config) {
       {
         pattern: specStyles,
         watched: false
+      },
+      {
+        pattern: assetsPattern,
+        included: false,
+        served: true,
       }
     ],
+    proxies: {
+      '/~/': `/absolute/${srcPath}`
+    },
     preprocessors: preprocessors,
     skyPagesConfig: skyPagesConfig,
     webpack: testWebpackConfig.getWebpackConfig(skyPagesConfig, argv),

--- a/test/config-karma-shared.spec.js
+++ b/test/config-karma-shared.spec.js
@@ -74,7 +74,7 @@ describe('config karma shared', () => {
     mock.reRequire('../config/karma/shared.karma.conf')({
       set: (config) => {
         expect(config.files.pop()).toEqual({
-          pattern: path.join(cwd, `src/assets/**`),
+          pattern: path.join(cwd, 'src') + '/assets/**',
           included: false,
           served: true
         });

--- a/test/config-karma-shared.spec.js
+++ b/test/config-karma-shared.spec.js
@@ -67,6 +67,23 @@ describe('config karma shared', () => {
     });
   });
 
+  it('should serve and proxy assets', (done) => {
+    const cwd = 'custom-cwd';
+    spyOn(process, 'cwd').and.returnValue(cwd);
+
+    mock.reRequire('../config/karma/shared.karma.conf')({
+      set: (config) => {
+        expect(config.files.pop()).toEqual({
+          pattern: `${cwd}/src/assets/**`,
+          included: false,
+          served: true
+        });
+        expect(config.proxies['/~/']).toContain(`/absolute${cwd}`);
+        done();
+      }
+    });
+  });
+
   it('should ignore anything outside the src directory in webpackMiddleware', (done) => {
     mock('../config/sky-pages/sky-pages.config.js', {
       getSkyPagesConfig: () => ({

--- a/test/config-karma-shared.spec.js
+++ b/test/config-karma-shared.spec.js
@@ -74,7 +74,7 @@ describe('config karma shared', () => {
     mock.reRequire('../config/karma/shared.karma.conf')({
       set: (config) => {
         expect(config.files.pop()).toEqual({
-          pattern: `${cwd}/src/assets/**`,
+          pattern: path.join(cwd, `src/assets/**`),
           included: false,
           served: true
         });

--- a/test/config-karma-test.spec.js
+++ b/test/config-karma-test.spec.js
@@ -23,7 +23,7 @@ describe('config karma test', () => {
   });
 
   it('should load the shared config', (done) => {
-    require('../config/karma/test.karma.conf')({
+    mock.reRequire('../config/karma/test.karma.conf')({
       set: (config) => {
         expect(config.browsers).toBeDefined();
         expect(called).toEqual(true);
@@ -34,7 +34,7 @@ describe('config karma test', () => {
 
   it('should use a custom launcher for Travis', (done) => {
     process.env.TRAVIS = true;
-    require('../config/karma/test.karma.conf')({
+    mock.reRequire('../config/karma/test.karma.conf')({
       set: (config) => {
         expect(config.browsers[0]).toBe('Chrome_travis_ci');
         delete process.env.TRAVIS;
@@ -48,7 +48,7 @@ describe('config karma test', () => {
       headless: true
     };
 
-    require('../config/karma/test.karma.conf')({
+    mock.reRequire('../config/karma/test.karma.conf')({
       set: (config) => {
         expect(config.browsers[0]).toBe('ChromeHeadless');
         done();
@@ -56,14 +56,31 @@ describe('config karma test', () => {
     });
   });
 
-  it('should include the desktop notifications reporter if --enableDesktopNotifications flag set', (done) => {
+  it('should include the desktop notifications reporter if --enableDesktopNotifications flag set without other reporters', (done) => {
     mockArgv = {
       enableDesktopNotifications: true
     };
 
-    require('../config/karma/test.karma.conf')({
+    mock.reRequire('../config/karma/test.karma.conf')({
       set: (config) => {
         expect(config.reporters).toContain('notify');
+        done();
+      }
+    });
+  });
+
+  it('should include the desktop notifications reporter if --enableDesktopNotifications flag set with other reporters', (done) => {
+    mockArgv = {
+      enableDesktopNotifications: true
+    };
+
+    mock(path, (config) => {
+      config.reporters = ['custom'];
+    });
+
+    mock.reRequire('../config/karma/test.karma.conf')({
+      set: (config) => {
+        expect(config.reporters).toEqual(['custom', 'notify']);
         done();
       }
     });
@@ -74,7 +91,7 @@ describe('config karma test', () => {
       suppressUnfocusedTestOutput: true
     };
 
-    require('../config/karma/test.karma.conf')({
+    mock.reRequire('../config/karma/test.karma.conf')({
       set: (config) => {
         expect(config.mochaReporter).toEqual({ ignoreSkipped: true });
         done();


### PR DESCRIPTION
Addresses #34 

Removes the 404 warnings by serving the `src/assets` directory and mapping requests for `~/assets` to that directory.