### PR TITLE
Setting pathMatch property on redirects.

### DIFF
--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -104,7 +104,8 @@ function generateRedirects(skyAppConfig) {
     redirects = Object.keys(skyAppConfig.skyux.redirects).map(key => {
       return `{
   path: '${key}',
-  redirectTo: '${skyAppConfig.skyux.redirects[key]}'
+  redirectTo: '${skyAppConfig.skyux.redirects[key]}',
+  pathMatch: '${key ? 'prefix' : 'full'}'
 }`;
     });
   }

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -342,6 +342,35 @@ describe('SKY UX Builder route generator', () => {
     expect(redirectIndex).toBeLessThan(rootIndex);
   });
 
+  it('should set `pathMatch` to prefix unless root redirect', () => {
+    spyOn(glob, 'sync').and.returnValue(['custom/nested/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    spyOn(fs, 'readFileSync').and.returnValue('');
+
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      },
+      skyux: {
+        redirects: {
+          '': 'root-redirect',
+          'old': 'new'
+        }
+      }
+    });
+
+    expect(routes.declarations).toContain(`{
+  path: '',
+  redirectTo: 'root-redirect',
+  pathMatch: 'full'
+},
+{
+  path: 'old',
+  redirectTo: 'new',
+  pathMatch: 'prefix'
+}`);
+  });
+
   it('should add the NotFoundComponent if route does not exist', () => {
     spyOn(glob, 'sync').and.returnValue(['index.html']);
     spyOn(path, 'join').and.returnValue('');


### PR DESCRIPTION
Without this property, I am unable to redirect the initial / root request. `prefix` is the default value, so I'm setting that for all other redirects except if empty, which signifies the root request.

https://angular.io/api/router/Route#pathMatch

This work is to support an update to the `addin-template`, where I want to keep the `my-tile` route but also automatically redirect to that route (for now) when running `skyux serve`.