### PR TITLE
[rc] Use `public_api.ts` for libraries

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -118,7 +118,7 @@ function transpile() {
 function writePackagerConfig(skyPagesConfig) {
   const ngPackageConfig = {
     lib: {
-      entryFile: 'index.ts'
+      entryFile: 'public_api.ts'
     }
   };
 
@@ -149,25 +149,14 @@ function writePackagerConfig(skyPagesConfig) {
 }
 
 /**
- * Create a secondary entrypoint for a `testing` module, if it exists.
+ * Configure a secondary entrypoint for a `testing` module, if it exists.
  */
 function createTestingEntryPoint() {
-  const testingEntryPoint = skyPagesConfigUtil.spaPathTemp('testing/index.ts');
+  const testingEntryPoint = skyPagesConfigUtil.spaPathTemp('testing/public_api.ts');
   if (fs.existsSync(testingEntryPoint)) {
-    // Need to create a root-level barrel file so that the `testing` files can locate
-    // the primary source files during compilation.
-    // See: https://github.com/ng-packagr/ng-packagr/issues/358#issuecomment-526650736
-    fs.writeFileSync(
-      skyPagesConfigUtil.spaPathTemp('public_api.testing.ts'),
-      `export * from './testing';\n`,
-      {
-        encoding: 'utf8'
-      }
-    );
-
     fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('testing/ng-package.json'), {
       lib: {
-        entryFile: '../public_api.testing.ts'
+        entryFile: 'public_api.ts'
       }
     });
   }

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -130,7 +130,7 @@ describe('cli build-public-library', () => {
 
     expect(writeSpy).toHaveBeenCalledWith('temp/ng-package.json', {
       lib: {
-        entryFile: 'index.ts'
+        entryFile: 'public_api.ts'
       }
     });
 
@@ -186,26 +186,17 @@ describe('cli build-public-library', () => {
   it('should include testing entry point if directory exists', async (done) => {
     spyOn(mockFs, 'existsSync').and.returnValue(true);
 
-    const writeSpy = spyOn(mockFs, 'writeFileSync').and.callThrough();
     const writeJsonSpy = spyOn(mockFs, 'writeJSONSync').and.callThrough();
     const pathSpy = spyOn(mockSkyPagesConfig, 'spaPathTemp').and.callThrough();
     const cliCommand = mock.reRequire(requirePath);
 
     await cliCommand({}, {});
 
-    expect(pathSpy).toHaveBeenCalledWith('testing/index.ts');
-
-    expect(writeSpy).toHaveBeenCalledWith(
-      'temp/public_api.testing.ts',
-      `export * from './testing';\n`,
-      {
-        encoding: 'utf8'
-      }
-    );
+    expect(pathSpy).toHaveBeenCalledWith('testing/public_api.ts');
 
     expect(writeJsonSpy).toHaveBeenCalledWith('temp/testing/ng-package.json', {
       lib: {
-        entryFile: '../public_api.testing.ts'
+        entryFile: 'public_api.ts'
       }
     });
 
@@ -248,7 +239,7 @@ describe('cli build-public-library', () => {
 
     expect(spy).toHaveBeenCalledWith('temp/ng-package.json', {
       lib: {
-        entryFile: 'index.ts'
+        entryFile: 'public_api.ts'
       },
       whitelistedNonPeerDependencies: [
         'foobar'
@@ -276,7 +267,7 @@ describe('cli build-public-library', () => {
 
     expect(spy).toHaveBeenCalledWith('temp/ng-package.json', {
       lib: {
-        entryFile: 'index.ts'
+        entryFile: 'public_api.ts'
       }
     });
 


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-sdk-builder/issues/246

Use `ng-packagr`'s preferred entry point of `public_api.ts` instead of `index.ts` for two reasons:
  1. We want our libraries to mimic closely what Angular CLI requires so that the eventual conversion will be easier.
  2. Angular recommends against using `index.ts` "barrel" files within libraries, so it will make the migration process easier if we tell our consumers to delete all index.ts files and not have to make a special concession for `src/app/public/index.ts`. (I've already rigged up the migration plugin to change the name of `src/app/public/index.ts` to `src/app/public/public_api.ts`.)
