### PR TITLE
Make `esModuleInterop` opt-in

### DIFF
--- a/cli/utils/run-build.js
+++ b/cli/utils/run-build.js
@@ -29,7 +29,7 @@ function writeTSConfig(skyPagesConfig) {
     });
   }
 
-  const config = {
+  let config = {
     'compilerOptions': {
       'target': 'es5',
       'module': 'es2015',
@@ -43,7 +43,6 @@ function writeTSConfig(skyPagesConfig) {
       'inlineSources': true,
       'declaration': true,
       'skipLibCheck': true,
-      'esModuleInterop': true,
       'lib': [
         'es2015',
         'dom'
@@ -68,7 +67,28 @@ function writeTSConfig(skyPagesConfig) {
     'buildOnSave': false
   };
 
+  config = applySpaTsConfig(config);
+
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTempSrc('tsconfig.json'), config);
+}
+
+/**
+ * Applies supported properties from the SPA's tsconfig.json file to the build config.
+ * @param {*} config The tsconfig.json JSON contents.
+ */
+function applySpaTsConfig(config) {
+  const spaTsConfig = fs.readJsonSync(skyPagesConfigUtil.spaPath('tsconfig.json'));
+  const compilerOptionsKeys = [
+    'esModuleInterop'
+  ];
+
+  compilerOptionsKeys.forEach(key => {
+    if (spaTsConfig.compilerOptions[key]) {
+      config.compilerOptions[key] = spaTsConfig.compilerOptions[key];
+    }
+  });
+
+  return config;
 }
 
 function stageAot(skyPagesConfig, assetsBaseUrl, assetsRel) {

--- a/test/cli-utils-run-build.spec.js
+++ b/test/cli-utils-run-build.spec.js
@@ -39,6 +39,11 @@ describe('cli utils run build', () => {
       readFileSync() {
         return '{}';
       },
+      readJsonSync() {
+        return {
+          compilerOptions: {}
+        };
+      },
       removeSync() {},
       writeFileSync() {},
       writeJSONSync() {},
@@ -330,5 +335,47 @@ describe('cli utils run build', () => {
       );
       done();
     });
+  });
+
+  it('should apply supported properties to `compilerOptions` from SPA\'s tsconfig.json', (done) => {
+
+    mock('../config/webpack/build-aot.webpack.config', {
+      getWebpackConfig: () => ({})
+    });
+
+    spyOn(mockFsExtra, 'readJsonSync').and.returnValue({
+      compilerOptions: {
+        esModuleInterop: true,
+        foo: 'bar'
+      }
+    });
+
+    const fsSpy = spyOn(mockFsExtra, 'writeJSONSync').and.callThrough();
+
+    const runBuild = mock.reRequire('../cli/utils/run-build');
+
+    runBuild({}, {
+      runtime: runtimeUtils.getDefaultRuntime(),
+      skyux: {
+        compileMode: 'aot'
+      }
+    }, () => ({
+      run: (cb) => {
+        cb(
+          null,
+          {
+            toJson: () => ({
+              errors: [],
+              warnings: []
+            })
+          }
+        );
+      }
+    })).then(() => {
+      const tsConfig = fsSpy.calls.argsFor(0)[1];
+      expect(tsConfig.compilerOptions.esModuleInterop).toEqual(true);
+      expect(tsConfig.compilerOptions.foo).toBeUndefined();
+      done();
+    }).catch(err => fail(err));
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "noUnusedLocals": true,
     "noImplicitAny": true,
     "noResolve": false,
-    "esModuleInterop": true,
     "lib": [
       "dom",
       "es6"


### PR DESCRIPTION
This pull request appears to be causing some unwanted side-effects:
https://github.com/blackbaud/skyux-sdk-builder/pull/261

Partially resolves: https://github.com/blackbaud/skyux-sdk-builder/issues/54

Previously acceptable imports must be changed in order for builds to pass.
```
// Instead of:
import * as moment from 'moment';

// Do...
import moment from 'moment';
```

This pull request allows `esModuleInterop` to be set on the SPA's tsconfig.json file and used in the build.