### PR TITLE
[rc] Remove deprecated `reflect-metadata`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9398,7 +9398,8 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "portfinder": "1.0.26",
     "protractor": "7.0.0",
     "raw-loader": "1.0.0",
-    "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",
     "sass": "1.26.5",
     "sass-loader": "8.0.2",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -14,6 +14,9 @@ import 'core-js/es/map';
 import 'core-js/es/weak-map';
 import 'core-js/es/set';
 
+/* IE10 and IE11 requires the following for the Reflect API. */
+import 'core-js/es/reflect';
+
 /**
  * Zone JS is required by default for Angular itself.
  */

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -14,13 +14,6 @@ import 'core-js/es/map';
 import 'core-js/es/weak-map';
 import 'core-js/es/set';
 
-/* IE10 and IE11 requires the following for the Reflect API. */
-import 'core-js/es/reflect';
-
-/* Evergreen browsers require these. */
-// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-import 'core-js/proposals/reflect-metadata';
-
 /**
  * Zone JS is required by default for Angular itself.
  */

--- a/utils/spec-bundle.js
+++ b/utils/spec-bundle.js
@@ -5,8 +5,6 @@
 require('zone.js/dist/zone');
 require('zone.js/dist/zone-testing');
 
-require('reflect-metadata');
-
 const testing = require('@angular/core/testing');
 const browser = require('@angular/platform-browser-dynamic/testing');
 


### PR DESCRIPTION
See: https://angular.io/guide/deprecations#dependency-on-a-reflect-metadata-polyfill-in-jit-mode