### PR TITLE
feat: upgrade to lib-help@3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,9 +1299,9 @@
       "dev": true
     },
     "@blackbaud/skyux-lib-help": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-help/-/skyux-lib-help-3.2.0.tgz",
-      "integrity": "sha512-W61TRa/fEMpKt7hh3eJhCpLMQITQfsOzjuURi48lbT6M8EAEuHjVLZhEltNcJclcHv2gT7U6p3mH4PrqpC8sPQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-help/-/skyux-lib-help-3.3.0.tgz",
+      "integrity": "sha512-2m3l8GcIWdOIRNWWdbL5QKA2vTQZBVzg+WvemPooAyaALAHjf6o683iCWNRyRfdDWne0QLCht3NX0ksn0TKArw=="
     },
     "@blackbaud/skyux-logger": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.0",
     "@blackbaud/help-client": "2.1.0",
-    "@blackbaud/skyux-lib-help": "3.2.0",
+    "@blackbaud/skyux-lib-help": "3.3.0",
     "@blackbaud/skyux-logger": "1.1.2",
     "@ngtools/webpack": "7.3.9",
     "@pact-foundation/karma-pact": "2.2.0",


### PR DESCRIPTION
this is to supplement an odd use case for the edu team

Note, i'm intending for this to get into skyux3. im pretty sure master is still the branch for that since 4 is in a rc branch.

[Changelog entry](https://github.com/blackbaud/skyux-lib-help/blob/master/CHANGELOG.md):

```
## 3.3.0 (2020-03-24)

- Updated Acorn from `6.3.0` to `6.4.1` to address a security vulnerability. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
- Added a capability to extend the configuration at runtime. [#57](https://github.com/blackbaud/skyux-lib-help/pull/57)
```