### PR TITLE
Moved `SkyThemeService` provider to `SkyPagesModule`

### DIFF
--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -94,7 +94,8 @@ function getSource(skyAppConfig) {
       ],
       useFactory: skyViewkeeperHostOptionsFactory
     }`,
-    'SkyAuthTokenProvider'
+    'SkyAuthTokenProvider',
+    'SkyThemeService'
   ];
 
   let nodeModuleImports = [
@@ -107,7 +108,7 @@ function getSource(skyAppConfig) {
     `import { SkyAppRuntimeConfigParams, SkyAppConfig } from '@skyux/config';`,
     `import { SkyAppWindowRef } from '@skyux/core';`,
     `import { SkyAuthTokenProvider } from '@skyux/http';`,
-    `import { SkyThemeModule } from '@skyux/theme';`,
+    `import { SkyThemeModule, SkyThemeService } from '@skyux/theme';`,
     `import { SkyI18nModule } from '@skyux/i18n';`,
     `import { SkyAppTitleService, SkyViewkeeperHostOptions } from '@skyux/core';`
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.0.0-rc.16",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -93,10 +93,7 @@ function fixUpNav(nav: any, baseUrl: string, config: SkyAppConfig) {
 
 @Component({
   selector: 'sky-pages-app',
-  templateUrl: './app.component.html',
-  providers: [
-    SkyThemeService
-  ]
+  templateUrl: './app.component.html'
 })
 export class AppComponent implements OnInit, OnDestroy {
   public isReady = false;


### PR DESCRIPTION
This allows components created outside of the `AppComponent` hierarchy (such as modals) to inject the app's instance of `SkyThemeService`.