### PR TITLE
Extend tsconfig compiler options to libraries

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -110,7 +110,7 @@ function writeTSConfig() {
     }
   };
 
-  tsconfig = applyLibraryTsConfig(tsconfig);
+  tsConfig = applyLibraryTsConfig(tsConfig);
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('tsconfig.lib.json'), tsConfig);
 }
 

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -80,8 +80,28 @@ function cleanRuntime() {
   rimraf.sync(skyPagesConfigUtil.spaPath('dist', 'runtime'));
 }
 
+/**
+ * Applies supported properties from the Library's tsconfig.json file to the build config.
+ * @param {*} config The tsconfig.json JSON contents.
+ */
+function applyLibraryTsConfig(config) {
+  const spaTsConfig = fs.readJsonSync(skyPagesConfigUtil.spaPath('tsconfig.json'));
+  const compilerOptionsKeys = [
+    'esModuleInterop',
+    'allowSyntheticDefaultImports'
+  ];
+
+  compilerOptionsKeys.forEach(key => {
+    if (spaTsConfig && spaTsConfig.compilerOptions && spaTsConfig.compilerOptions[key]) {
+      config.compilerOptions[key] = spaTsConfig.compilerOptions[key];
+    }
+  });
+
+  return config;
+}
+
 function writeTSConfig() {
-  const tsConfig = {
+  let tsConfig = {
     extends: skyPagesConfigUtil.spaPath(
       'node_modules/ng-packagr/lib/ts/conf/tsconfig.ngc.json'
     ),
@@ -90,6 +110,7 @@ function writeTSConfig() {
     }
   };
 
+  tsconfig = applyLibraryTsConfig(tsconfig);
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('tsconfig.lib.json'), tsConfig);
 }
 

--- a/cli/utils/run-build.js
+++ b/cli/utils/run-build.js
@@ -86,7 +86,8 @@ function writeTSConfig(skyPagesConfig) {
 function applySpaTsConfig(config) {
   const spaTsConfig = fs.readJsonSync(skyPagesConfigUtil.spaPath('tsconfig.json'));
   const compilerOptionsKeys = [
-    'esModuleInterop'
+    'esModuleInterop',
+    'allowSyntheticDefaultImports'
   ];
 
   compilerOptionsKeys.forEach(key => {


### PR DESCRIPTION
As part of this issue: https://github.com/blackbaud/skyux-sdk-builder/issues/54

Libraries are unable to supply necessary flags like `esModuleInterop` and `allowSyntheticDefaultImports` for interfacing with commonjs libraries. This will take in a whitelisted set of compiler options from the library's tsconfig.json to add to the build tsconfig.
Right now the white list only includes these 2 options.