### PR TITLE
Allow SkyAuthTokenProvider to be overridden by AppExtrasModule

### DIFF
--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -172,8 +172,10 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          include: spaPath('src'),
-          exclude: /node_modules/
+          include: [
+            spaPath('src'),
+            outPath('runtime')
+          ]
         },
         {
           test: /\.s?css$/,

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -38,11 +38,6 @@ function getWebpackConfig(skyPagesConfig, argv) {
     outPath('node_modules')
   ];
 
-  const excludes = [
-    spaPath('node_modules'),
-    outPath('node_modules')
-  ];
-
   skyPagesConfig.runtime.includeRouteModule = false;
 
   let alias = aliasBuilder.buildAliasList(skyPagesConfig);
@@ -80,7 +75,10 @@ function getWebpackConfig(skyPagesConfig, argv) {
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          exclude: excludes
+          include: [
+            spaPath('src'),
+            outPath('runtime')
+          ]
         },
         {
           enforce: 'pre',

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -90,7 +90,6 @@ function getSource(skyAppConfig) {
       ],
       useFactory: skyViewkeeperHostOptionsFactory
     }`,
-    'SkyAuthTokenProvider',
     'SkyThemeService'
   ];
 
@@ -102,7 +101,6 @@ function getSource(skyAppConfig) {
     `import { SkyAppAssetsService } from '@skyux/assets';`,
     `import { SkyAppRuntimeConfigParams, SkyAppConfig } from '@skyux/config';`,
     `import { SkyAppWindowRef } from '@skyux/core';`,
-    `import { SkyAuthTokenProvider } from '@skyux/http';`,
     `import { SkyThemeModule, SkyThemeService } from '@skyux/theme';`,
     `import { SkyI18nModule } from '@skyux/i18n';`,
     `import { SkyAppTitleService, SkyViewkeeperHostOptions } from '@skyux/core';`
@@ -120,6 +118,7 @@ function getSource(skyAppConfig) {
     'ReactiveFormsModule',
     'SkyI18nModule',
     'SkyAppHostLocaleModule',
+    'SkyAppAuthTokenModule',
     'AppExtrasModule',
     'SkyThemeModule'
   ];
@@ -220,6 +219,10 @@ import {
 import {
   SkyAppHostLocaleModule
 } from '${skyAppConfig.runtime.runtimeAlias}/i18n/app-host-locale.module';
+
+import {
+  SkyAppAuthTokenModule
+} from '${skyAppConfig.runtime.runtimeAlias}/auth-token.module';
 
 ${assetsGenerator.getSource()}
 

--- a/runtime/auth-token.module.ts
+++ b/runtime/auth-token.module.ts
@@ -1,0 +1,18 @@
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyAuthTokenProvider
+} from '@skyux/http';
+
+/**
+ * We must provide `SkyAuthTokenProvider` in its own module to allow `app-extras.module.ts` to
+ * override the provider.
+ */
+@NgModule({
+  providers: [
+    SkyAuthTokenProvider
+  ]
+})
+export class SkyAppAuthTokenModule { }


### PR DESCRIPTION
Confirmed this worked with consumer SPAs that implement Pact tests. 

Related: https://github.com/blackbaud/skyux-sdk-builder-plugin-pact/pull/7