### PR TITLE
README: Point to non-deprecated sky cli repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 [![status](https://travis-ci.org/blackbaud/skyux-sdk-builder.svg?branch=master)](https://travis-ci.org/blackbaud/skyux-sdk-builder)
 [![coverage](https://codecov.io/gh/blackbaud/skyux-sdk-builder/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/blackbaud/skyux-sdk-builder/branch/master)
 
-Builds the output of a SKY UX application.  See [skyux-cli](https://github.com/blackbaud/skyux-cli) for more information.
+Builds the output of a SKY UX application.  See [skyux-sdk-cli](https://github.com/blackbaud/skyux-sdk-cli) for more information.


### PR DESCRIPTION
The current link goes to the deprecated sky-cli repository.