### PR TITLE
Release 4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.9.1 (2021-08-17)
+
+- Updated theme switcher to reflect theme changes on demo pages. [#361](https://github.com/blackbaud/skyux-sdk-builder/pull/361)
+
 # 4.9.0 (2021-05-28)
 
 - Support switching supported themes via SKY UX Host. [#359](https://github.com/blackbaud/skyux-sdk-builder/pull/359)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Builds the output of a SKY UX application.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Updated theme switcher to reflect theme changes on demo pages. [#361](https://github.com/blackbaud/skyux-sdk-builder/pull/361)
