### PR TITLE
Release 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.10.0 (2021-08-23)
+
+- Upgraded `selenium-standalone` to address security vulnerabilities. [#364](https://github.com/blackbaud/skyux-sdk-builder/pull/364)
+
 # 4.9.1 (2021-08-17)
 
 - Updated theme switcher to reflect theme changes on demo pages. [#361](https://github.com/blackbaud/skyux-sdk-builder/pull/361)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "description": "Builds the output of a SKY UX application.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Upgraded `selenium-standalone` to address security vulnerabilities. [#364](https://github.com/blackbaud/skyux-sdk-builder/pull/364)
