### PR TITLE
Install `jasmine-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.12.2 (2022-01-20)
 
-- Added `jasmine-core@3.6.0` to package dependencies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which introduces breaking changes for our consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
+- Added `jasmine-core@3.6.0` to the package dependencies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0`, which introduces breaking changes for our consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
 
 # 4.12.1 (2021-10-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 4.12.2 (2022-01-19)
+# 4.12.2 (2022-01-20)
 
-- Added `jasmine-core@3.6.0` to package dependenies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which has known breaking changes with current consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
+- Added `jasmine-core@3.6.0` to package dependenies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which introduces breaking changes for our consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
 
 # 4.12.1 (2021-10-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.12.2 (2022-01-19)
+
+- Added `jasmine-core@3.6.0` to package dependenies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which has known breaking changes with current consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
+
 # 4.12.1 (2021-10-15)
 
 - Fixed the app component to initialize the Help service immediately after the page loads. [#369](https://github.com/blackbaud/skyux-sdk-builder/pull/369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.12.2 (2022-01-20)
 
-- Added `jasmine-core@3.6.0` to package dependenies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which introduces breaking changes for our consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
+- Added `jasmine-core@3.6.0` to package dependencies to prevent `karma-jasmine` from installing `jasmine-core@3.99.0` which introduces breaking changes for our consumers. [#371](https://github.com/blackbaud/skyux-sdk-builder/pull/371)
 
 # 4.12.1 (2021-10-15)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6966,12 +6966,19 @@
       "requires": {
         "glob": "^7.1.4",
         "jasmine-core": "~3.5.0"
+      },
+      "dependencies": {
+        "jasmine-core": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
+          "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA=="
+        }
       }
     },
     "jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
+      "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw=="
     },
     "jasmine-spec-reporter": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/builder",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Builds the output of a SKY UX application.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "hash-file": "3.0.0",
     "html-webpack-plugin": "4.5.0",
     "jasmine": "3.5.0",
+    "jasmine-core": "3.6.0",
     "jasmine-spec-reporter": "6.0.0",
     "karma": "5.2.3",
     "karma-chrome-launcher": "3.1.0",

--- a/utils/spec-styles.js
+++ b/utils/spec-styles.js
@@ -9,6 +9,8 @@ const styleLoader = require('@skyux/theme/utils/node-js/style-loader');
 // for the HTML hidden property defined in sky.scss has been applied.
 (function () {
   beforeAll(function (done) {
-    styleLoader.loadStyles().then(done);
+    styleLoader.loadStyles().then(() => {
+      done();
+    });
   });
 }());


### PR DESCRIPTION
The package `karma-jasmine` is pulling in `jasmine-core@3.99.0` which introduces some breaking changes for our consumers. We can address this by installing the version of `jasmine-core` to the minimum required version listed by `karma-jasmine`, allowing the version of `jasmine-core` to be deduped between `jasmine` and `karma-jasmine`.